### PR TITLE
Fix code intent AND prevents GCC compile error

### DIFF
--- a/cpp/src/command_classes/AssociationCommandConfiguration.cpp
+++ b/cpp/src/command_classes/AssociationCommandConfiguration.cpp
@@ -183,7 +183,7 @@ namespace OpenZWave
 					if (Node* node = GetNodeUnsafe())
 					{
 						Group* group = node->GetGroup(groupIdx);
-						if ( NULL == group)
+						if ( NULL != group)
 						{
 							if (firstReports)
 							{


### PR DESCRIPTION
Very small code fix. See also OpenZwave issue [2613](https://github.com/OpenZWave/open-zwave/issues/2613).

As it doesn't get fixed upstream as it seems, let's do it here so we can continue for now.

In the future, Domoticz will drop direct OpenZwave support (and not use this abandoned library anymore)